### PR TITLE
chore: switch project to pnpm (pnpm@10.31.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,31 +5,32 @@ https://github.com/shizuku86/Kairo
 
 After cloning, run the following command to install node_modules:
 
-- npm install
+- pnpm install
 
 After editing the lines ending with # in scripts/properties.ts appropriately and resolving errors,  
 execute the following command in the terminal:
 
-- npm run build
+- pnpm run build
 
 When this command is executed, the following operations will be performed:
 
 - manifest.json is automatically generated in BP/ and RP/ from the information in properties
-- TypeScript files in scripts/ are built as JavaScript into BP/scripts
+- TypeScript files in scripts/ are type-checked with TypeScript, then bundled with esbuild into BP/scripts
 - The pack_icon.png at the project root is copied into both BP/ and RP/
 - The completed BP/ and RP/ are copied into Minecraft’s development folder
 
 ## Requirements
 
-- Node.js (for development and TypeScript build)
+- Node.js (for development and build tooling)
+- pnpm 10.31.0
 
 ## Setup && Build
 
 1. Install dependencies:
     ```bash
-    npm install
+    pnpm install
     ```
 2. Deploy
     ```bash
-    npm run build
+    pnpm run build
     ```

--- a/package.json
+++ b/package.json
@@ -4,8 +4,9 @@
     "description": "**Stable Script API**\r - @minecraft/server - 2.5.0",
     "main": "index.js",
     "type": "module",
+    "packageManager": "pnpm@10.31.0",
     "scripts": {
-        "build": "node src/generate-event-imports.js && rimraf BP/scripts && tsc --noEmit && node build.mjs && npm run deploy",
+        "build": "node src/generate-event-imports.js && rimraf BP/scripts && tsc --noEmit && node build.mjs && pnpm run deploy",
         "deploy": "node src/deploy.js"
     },
     "repository": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,7 @@
         // For nodejs:
         // "lib": ["esnext"],
         // "types": ["node"],
-        // and npm install -D @types/node
+        // and pnpm add -D @types/node
 
         // Other Outputs
         "sourceMap": false,


### PR DESCRIPTION
### Motivation
- Replace npm with pnpm as the primary package manager to standardize installs and CI usage while keeping the existing esbuild-based bundling in the build pipeline.
- Update developer documentation and small tooling notes to reflect the new workflow.

### Description
- Added `"packageManager": "pnpm@10.31.0"` to `package.json` and changed the `build` script to call `pnpm run deploy` instead of `npm run deploy`.
- Updated `README.md` to use `pnpm install` / `pnpm run build` and clarified that the build step performs TypeScript type-checking then bundles with `esbuild`.
- Adjusted the `tsconfig.json` comment to recommend `pnpm add -D @types/node` for consistency with the pnpm workflow.

### Testing
- Ran a JSON check script with `node -e ...` to verify `package.json` contains `packageManager: pnpm@10.31.0` and the `build` script calls `pnpm run deploy`, which succeeded.
- Ran the existing build entry script with `node build.mjs`, which completed successfully.
- Attempted `pnpm --version` to validate the local pnpm install, which failed due to network/proxy issues when Corepack tried to fetch `pnpm@10.31.0` (environmental failure, not a repository change).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69acf97923c48333a2bdcd39cdb924e8)